### PR TITLE
predictive flipper collision @PXR-005

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,23 +1,28 @@
+// Three js
 import * as THREE from 'three';
+// Cannon es
 import * as CANNON from 'cannon-es';
+// Dev/Debug
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import CannonDebugger from 'cannon-es-debugger';
 import Stats from 'stats.js';
-import { initCannonBodies } from 'cannon/bodies';
-import { initContactMaterials } from 'cannon/materials';
-import { initInputEventListeners } from './inputEvents';
-//import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+// Objects
 import Flipper from './cannon/objects/Flipper';
 import KeyEvents from './inputEvents';
 
-//////////////
-// INIT CANNON
+
+// INIT CANNON ES
 const world = new CANNON.World();
 world.gravity.set(0, -30, 0);
 world.broadphase = new CANNON.NaiveBroadphase();
-
-
-// FLOOR
+// INIT THREE JS
+const scene = new THREE.Scene()
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
+camera.position.set(0, 15, 5);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+// ADD TEST FLOOR
 const floorShape = new CANNON.Box(new CANNON.Vec3(5, .25, 5));
 const floorBody = new CANNON.Body({
   mass: 0,
@@ -28,35 +33,16 @@ world.addBody(floorBody);
 let quat = new CANNON.Quaternion();
 quat.setFromAxisAngle(new CANNON.Vec3( 1, 0, 0 ), Math.PI/180 * 3);
 floorBody.quaternion.copy(quat);
-
-// BALL
+// ADD BALL
 const ballShape = new CANNON.Sphere(.25);
-const ballBody = new CANNON.Body({ mass: 10, position: new CANNON.Vec3(Math.random() * 2.25 + 1, 2, -4) });
+const ballBody = new CANNON.Body({ mass: 10, position: new CANNON.Vec3(Math.random() * 2.25 + 3, 2, -6) });
+ballBody.velocity.x = -2;
+ballBody.velocity.z = 4;
 ballBody.addShape(ballShape);
 world.addBody(ballBody);
-
-// LEFT FLIPPER 
-const leftFlipper = new Flipper({ world });
-
-//////////////
-// INIT THREE
-const scene = new THREE.Scene()
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
-camera.position.set(0, 9, 13);
-const renderer = new THREE.WebGLRenderer();
-renderer.setSize(window.innerWidth, window.innerHeight);
-document.body.appendChild(renderer.domElement);
-
-
-///////////
-// HELPERS
-window.addEventListener('resize', onWindowResize, false)
-function onWindowResize() {
-    camera.aspect = window.innerWidth / window.innerHeight
-    camera.updateProjectionMatrix()
-    renderer.setSize(window.innerWidth, window.innerHeight)
-    render()
-}
+// ADD LEFT FLIPPER 
+const leftFlipper = new Flipper({ world, ballRef: ballBody });
+// DEV/DEBUG HELPERS
 const cannonDebugger = new CannonDebugger(scene, world);
 const controls = new OrbitControls(camera, renderer.domElement);
 const stats = new Stats();
@@ -64,17 +50,6 @@ stats.showPanel(0);
 document.body.appendChild(stats.dom);
 const axesHelper = new THREE.AxesHelper( 5 );
 scene.add( axesHelper );
-
-
-
-/////////////////
-// ANIMATION LOOP
-const clock = new THREE.Clock();
-let delta;
-const timeStep = 1/60;
-const maxSubSteps = 5;
-
-//////////////////
 // KEYBOARD INPUT
 const keyEvents = new KeyEvents();
 keyEvents.addSubscriber({ 
@@ -87,22 +62,34 @@ keyEvents.addSubscriber({
   keyAction: 'keyup', 
   callBack: leftFlipper.onFlipperDown
   });
-
-// REQUEST ANIMATION LOOP
+// INIT ANIMATION VALUES
+const clock = new THREE.Clock();
+let delta;
+const timeStep = 1/60;
+const maxSubSteps = 5;
+// ANIMATION LOOP
 function animate() {
   stats.begin();
   controls.update();
   cannonDebugger.update();
-  leftFlipper.step();
+  leftFlipper.step(ballBody);
   delta = Math.min(clock.getDelta(), 0.1)
   world.step(timeStep, delta, maxSubSteps);   
-  render();
+  renderer.render(scene, camera)
   stats.end();
   requestAnimationFrame(animate);
 }
-
-function render() {
-  renderer.render(scene, camera)
-}
-
+// START ANIMATION
 animate();
+
+
+
+
+// HELPERS
+window.addEventListener('resize', onWindowResize, false)
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight
+    camera.updateProjectionMatrix()
+    renderer.setSize(window.innerWidth, window.innerHeight)
+    render()
+}

--- a/src/cannon/constants.js
+++ b/src/cannon/constants.js
@@ -1,5 +1,6 @@
 import * as CANNON from 'cannon-es';
 
+// SLOPE OF PINBALL PLAYFIELD
 export const quaternionPlayfieldSlope = new CANNON.Quaternion();
 quaternionPlayfieldSlope.setFromAxisAngle(new CANNON.Vec3( 1, 0, 0 ), Math.PI/180 * 6);
 

--- a/src/cannon/objects/Flipper/index.js
+++ b/src/cannon/objects/Flipper/index.js
@@ -1,86 +1,45 @@
 import * as CANNON from 'cannon-es';
-import { flipperMaterial } from '../../materials/index';
 
 function Flipper ({
-  world
+  world,
+  ballRef
   }) {
-  this.body = this.createBody({ world });
+// PINBALL POSITION AND SIZE
+  this.ballRef = ballRef;
+  this.ballRadius= ballRef.shapes[0].radius;
+// CREATE CANNON BODY  
+  this.flipperLengthFromPivot = 3.5;
+  this.flipperPos = new CANNON.Vec3(0, 0.6, 0);
+  this.body = null;
+  this.createBody = this.createBody.bind(this);
 // ANIMATION
   this.step = this.step.bind(this);
-  this.animation = this.createAnimation();
+  this.animation = null;
   this.isAnimating = false;
   this.animationFrame = null;
   this.animationDirection = 1;
   this.animationStopAfterFrame = null;
+  this.createAnimation = this.createAnimation.bind(this);
 // INPUT EVENTS
   this.onFlipperUp = this.onFlipperUp.bind(this);
   this.onFlipperDown = this.onFlipperDown.bind(this);
-// COLLISION
+// COLLISION PREDICTION
   this.maxVelocity = 50;
-  this.collisionHandler = this.collisionHandler.bind(this);
-  this.body.addEventListener('collide', this.collisionHandler);
-}
-
-Flipper.prototype.collisionHandler = function (e) {
- // if (this.isAnimating === false) return;
-// to do: throttle collision events for 100 milliseconds after contact
-// to do: switch over to physics when ball is on unmoving flipper 'isTrigger true/false'
-  const { body, target } = {...e};
-// ANGLE OF BALL VECTOR (direction of ball)
-  const ballUnitVec = getBallUnitVec(body);
-// ANGLE OF FLIPPER VECTOR (orientation of flipper)
-  const flipperUnitVec = getFlipperUnitVec(ballUnitVec);
-// MAGNITUDE OF FLIPPER VECTOR (contact distance from flipper pivot point)
-  const flipperMagnitude = getFlipperMagnitude();
-// MAGNITUDE OF BALL VECTOR (velocity of ball along x and z axis)
-  const ballMagnitude = getBallMagnitude(body); 
-
-  const angleBetween = Math.acos(flipperUnitVec.dot(ballUnitVec));
-  const xDirection = flipperUnitVec.z < 0 ? 1 : -1;
-  e.body.velocity.x = Math.cos(angleBetween / 2) * this.maxVelocity * xDirection * flipperMagnitude;
-  e.body.velocity.z = Math.sin(angleBetween / 2) * this.maxVelocity * -(flipperMagnitude + ballMagnitude.z);
-  
-// ANGLE OF FLIPPER VECTOR 
-  function getFlipperUnitVec (ballUnitVec) {
-    const flipperAxis = new CANNON.Vec3(...Object.values(e.target.quaternion.toAxisAngle()[0]));
-    const flipperAngle = e.target.quaternion.toAxisAngle()[1] * flipperAxis.y;
-    return new CANNON.Vec3(Math.cos(flipperAngle), -ballUnitVec.y , Math.sin(flipperAngle));
-  }
-
-// ANGLE OF BALL VECTOR 
-  function getBallUnitVec ({ position, previousPosition }) {
-    const ballUnitVec = new CANNON.Vec3();
-    const ballPrevPos = new CANNON.Vec3();
-    const ballPos = new CANNON.Vec3();
-    const ballPosDiff = new CANNON.Vec3();
-    ballPrevPos.set(...Object.values(previousPosition));
-    ballPos.set(...Object.values(position));
-    ballPos.vsub(ballPrevPos, ballPosDiff);
-    ballPosDiff.unit(ballUnitVec);
-    return ballUnitVec;
-  }
-    
-// GET DISTANCE BETWEEN CURRENT X, Z POSTION AND PREVIOUS POSITION 
-  function getBallMagnitude ({ position, previousPosition }) {
-    return new CANNON.Vec3(position.x - previousPosition.x, position.y - previousPosition.y, position.z - previousPosition.z);
-  }
-// GET DISTANCE BETWEEN BALL CONTACT AND FLIPPER PIVOT POINT
-  function getFlipperMagnitude () {
-    const { quaternion, previousQuaternion } = target;
-    if (quaternion.y === previousQuaternion.y) return 0.1;
-    const flipperContactDistanceFromPivot = Math.sqrt(Math.pow(e.body.position.x - e.target.position.x, 2) +
-                                                      Math.pow(e.body.position.y - e.target.position.y, 2));
-    const flipperLength = 3.5;
-    return flipperContactDistanceFromPivot / flipperLength;
-  }
+  this.hitAreas = {};
+  this.collisionFrame = null;
+  this.collisionFrame = { frameNumber: null, ballVelocity: {}};
+  this.getCollisionFrame = this.getCollisionFrame.bind(this);
+// INIT FLIPPER
+  this.createBody({ world });
+  this.createAnimation();
 }
 
 Flipper.prototype.onFlipperUp = function () {
+  this.getCollisionFrame();
   this.isAnimating = true;
-  this.animationFrame = 0;
+  this.animationFrame = -1;
   this.animationDirection = 1;
   this.animationStopAfterFrame = this.animation.length - 1;
-  
 }
 
 Flipper.prototype.onFlipperDown = function () {
@@ -90,26 +49,36 @@ Flipper.prototype.onFlipperDown = function () {
   this.animationStopAfterFrame = 0;
 }
 
-Flipper.prototype.step = function () {
+// REQUEST ANIM FRAME LOOP
+Flipper.prototype.step = function ({ position, previousPosition }) {
   if (this.isAnimating === false) return; 
+// BEGIN FRAME
+  this.animationFrame += this.animationDirection;
+// UPDATE FLIPPER POSITION
   this.body.quaternion.copy(this.animation[this.animationFrame]);
+// CHECK IF COLLISION FRAME
+  if (this.animationFrame === this.collisionFrame.frame) {
+    console.log('this.collisionFrame', this.collisionFrame)
+    console.log('this.collisionFrame.velocity', this.collisionFrame.velocity);
+    this.ballRef.velocity.set(...Object.values(this.collisionFrame.velocity));
+  }
+// CHECK IF LAST ANIMATION FRAME HAS BEEN RENDERED
   if (this.animationFrame === this.animationStopAfterFrame) {
     this.isAnimating = false;
-  } else {
-    this.animationFrame += this.animationDirection;
   }
 }
 
+
 Flipper.prototype.createBody = function ({ world }) {
-  const shape = new CANNON.Box(new CANNON.Vec3(2, 0.4, 0.4));
+  const shape = new CANNON.Box(new CANNON.Vec3(2, 0.4, 0.1));
   const body = new CANNON.Body({
     mass: 0,
     isTrigger: true,
-    position: new CANNON.Vec3(0, 0.6, 0)
+    position: this.flipperPos
   });
   body.addShape(shape, new CANNON.Vec3(1.5, 0, 0));
   world.addBody(body);
-  return body;
+  this.body = body;
 }
 
 Flipper.prototype.createAnimation = function () {
@@ -117,18 +86,79 @@ Flipper.prototype.createAnimation = function () {
   quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), -Math.PI/6);
   this.body.quaternion.copy(quat);
   const startRadian = -Math.PI/6;
-  const endRadian = Math.PI/5;
+  const endRadian = Math.PI/4;
   const animSteps = 4;
   const increment = (Math.abs(startRadian) + endRadian) / animSteps;
   const rotationAnim = [];
+  const flipperAngles = []
   for (let r = startRadian; r < endRadian; r += increment) {
+    const adjustedForFlipperWidth = 0.01;
+    flipperAngles.push(r + adjustedForFlipperWidth);
     const quat = new CANNON.Quaternion();
     quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), r);
     rotationAnim.push(quat);
   }
-  return rotationAnim;
+  this.hitAreas = flipperAngles.map((angle, idx) => {
+    const hitArea = { min: null, max: null, minDegrees: null, maxDegrees: null };
+    if (idx > 0) {
+      hitArea.min = flipperAngles[idx-1];
+      hitArea.max = flipperAngles[idx];
+      hitArea.minDegrees = flipperAngles[idx-1] * 180/Math.PI;
+      hitArea.maxDegrees = flipperAngles[idx] * 180/Math.PI;
+    }
+    return hitArea;
+  })
+  this.animation = rotationAnim;
+}
+
+Flipper.prototype.getCollisionFrame = function () {
+  this.collisionFrame = { frame: -1 };
+  const { position, previousPosition } = this.ballRef;
+  const ballPrevPos = new CANNON.Vec3(...Object.values(previousPosition));
+  const ballPos = new CANNON.Vec3(...Object.values(position));
+  const ballPosDiff = new CANNON.Vec3();
+  ballPos.vsub(ballPrevPos, ballPosDiff);
+  const ballUnitVec = new CANNON.Vec3();
+  ballPosDiff.unit(ballUnitVec);
+
+  for (let frame = 1; frame < this.hitAreas.length; frame++) {
+    const ballx = ballPos.x - frame * ballPosDiff.x;
+    const ballz = ballPos.z - frame * ballPosDiff.z;
+// HYPOTENUSE OF BALL CENTER TO FLIPPER PIVOT
+    const distanceFromCenter = Math.sqrt(Math.pow(ballx, 2) + Math.pow(ballz, 2));
+    if (distanceFromCenter > this.flipperLengthFromPivot) continue;
+// ANGLE BETWEEN BALL CENTER AND FLIPPER PIVOT
+    const angleFromCenter = -Math.atan(ballz/ballx);
+// ANGLE BETWEEN BALL CENTER, FLIPPER PIVOT, AND BALL CONTACT POINT
+    const angleBetweenCenterAndContactPoint = Math.asin(this.ballRadius/distanceFromCenter);
+// TARGET FLIPPER ANGLE FOR HIT AREA TEST
+    const targetAngleForHitAreaTest = angleFromCenter - angleBetweenCenterAndContactPoint;
+    const { min, max } = this.hitAreas[frame];
+console.log('')
+console.log(`frame ${frame}: test if ${targetAngleForHitAreaTest} < ${min} || ${targetAngleForHitAreaTest} > ${max}`)
+    if (targetAngleForHitAreaTest < min || targetAngleForHitAreaTest > max ) continue;
+    const tangentVelocity = {
+      x: -Math.sin(targetAngleForHitAreaTest),
+      z: -Math.cos(targetAngleForHitAreaTest)
+    }
+
+console.log('*****tangentVelocity', tangentVelocity)
+console.log('')
+
+    const flipperMagnitude = distanceFromCenter / this.flipperLengthFromPivot;
+    const velocity = new CANNON.Vec3(
+      tangentVelocity.x * this.maxVelocity * flipperMagnitude,
+      -ballPosDiff.y,
+      tangentVelocity.z * this.maxVelocity * flipperMagnitude
+  ) ;
+
+    this.collisionFrame = {
+      frame,
+      velocity
+    }
+    break;
+  }
 }
 
 export default Flipper;
-
 

--- a/src/inputEvents/index.js
+++ b/src/inputEvents/index.js
@@ -1,5 +1,4 @@
-// to do: make function prototype that throttles keyDown messages.
-
+// SUBSCRIBE TO KEYBOARD INPUTS
 function KeyEvents () {
   this.subscribers = {
     keydown: {},


### PR DESCRIPTION
Add predictive collision between flipper and ball.

@PXR-005 Due to the velocity of the pinball and the rate of flipper rotation, Cannon's collision detection is not able to reliably or accurately model a real-world pinball/flipper dynamic (assuming a ceiling of 60fps).