### PR TITLE
collision behavior added for at-rest flippers @PXR-007

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -37,10 +37,10 @@ floorBody.quaternion.copy(quat);
 const ballShape = new CANNON.Sphere(.25);
 const ballBody = new CANNON.Body({ 
   mass: 10, 
-  position: new CANNON.Vec3(0, 2, -6) 
+  position: new CANNON.Vec3(-5, 2, -8) 
 });
-ballBody.velocity.x = 1 + Math.random() * 2;
-ballBody.velocity.z = 4;
+ballBody.velocity.x = 2 + Math.random() * 1.25;
+ballBody.velocity.z = 6;
 ballBody.addShape(ballShape);
 world.addBody(ballBody);
 // ADD FLIPPERS 

--- a/src/cannon/bodies/BallBody/config/index.js
+++ b/src/cannon/bodies/BallBody/config/index.js
@@ -8,5 +8,5 @@ export const BALL_CONFIG = {
   position: new CANNON.Vec3(4.75, 0.1, 9),
   material: ballMaterial,
   collisionFilterGroup: COLLISION_GROUPS.BALL,
-  collisionFilterMask: COLLISION_GROUPS.PLAYFIELD
+  collisionFilterMask: COLLISION_GROUPS.PLAYFIELD | COLLISION_GROUPS.FLIPPER
 }

--- a/src/cannon/collisions/index.js
+++ b/src/cannon/collisions/index.js
@@ -3,7 +3,7 @@ import * as CANNON from 'cannon-es';
 export const COLLISION_GROUPS = {
   BALL: 1,
   PLAYFIELD: 2,
-  TRIGGERS: 4
+  FLIPPER: 4
 }
 
 

--- a/src/cannon/objects/Flipper/index.js
+++ b/src/cannon/objects/Flipper/index.js
@@ -1,5 +1,5 @@
 import * as CANNON from 'cannon-es';
-
+import { COLLISION_GROUPS } from '../../collisions';
 function Flipper ({
   world,
   ballRef,
@@ -12,9 +12,9 @@ function Flipper ({
 // CREATE CANNON BODY  
   this.flipperLengthFromPivot = 3.5;
   this.shapeOffset = new CANNON.Vec3(1.5, 0, 0)
-  this.flipperPos = new CANNON.Vec3(-4, 0.6, -1);
+  this.flipperPos = new CANNON.Vec3(-4, 0.3, -1);
   if (name === 'rightFlipper') {
-    this.flipperPos = new CANNON.Vec3(4, 0.6, -1);
+    this.flipperPos = new CANNON.Vec3(4, 0.3, -1);
   }
   this.body = null;
   this.createBody = this.createBody.bind(this);
@@ -27,7 +27,6 @@ function Flipper ({
   }
   this.step = this.step.bind(this);
   this.animation = null;
-  this.isAnimating = false;
   this.animationFrame = null;
   this.animationDirection = 1;
   this.animationStopAfterFrame = null;
@@ -45,54 +44,117 @@ function Flipper ({
   this.collisionFrame = null;
   this.collisionFrame = { frameNumber: null, ballVelocity: {}};
   this.getCollisionFrame = this.getCollisionFrame.bind(this);
+// COLLISION HANDLER
+  this.collisionHandler = this.collisionHandler.bind(this);
+// FLIPPER STATE
+  this.flipperState = {};
+  this.initFlipperState = this.initFlipperState.bind(this);
 // INIT FLIPPER
   this.createBody({ world });
   this.createAnimation();
+  this.initFlipperState();
+  this.body.addEventListener('collide', this.collisionHandler(this.flipperState))
+
+
 }
+
+Flipper.prototype.initFlipperState = function () {
+  const mirrorValue = this.name === 'leftFlipper' ? -1 : 1;
+  this.flipperState = {
+    isAnimating: false,
+    orientation: 'down',
+    tangentCollisionVector: { 
+      up: { 
+        x: Math.sin(this.endRadian) * mirrorValue,
+        z: Math.cos(this.endRadian) * mirrorValue
+      },
+      down: {
+        x: Math.sin(this.startRadian) * mirrorValue,
+        z: Math.cos(this.startRadian) * mirrorValue
+      }
+    }
+  }
+}
+
+Flipper.prototype.collisionHandler = (flipperStateRef) => {
+  return (e) => {
+    console.log('flipperStateRef:', flipperStateRef);
+// IF FLIPPER IS ANIMATING, DO NOTHING
+    if (flipperStateRef.isAnimating === true) return;
+// IF FLIPPER IS NOT ANIMATING, DETERMINE DIRECTION OF BALL
+    const { body:ball, target:flipper } = e;
+    const { position, previousPosition } = ball;
+    const ballPrevPos = new CANNON.Vec3(...Object.values(previousPosition));
+    const ballPos = new CANNON.Vec3(...Object.values(position));
+    const ballPosDiff = new CANNON.Vec3();
+    ballPos.vsub(ballPrevPos, ballPosDiff);
+    const ballUnitVec = new CANNON.Vec3(); // ballUnitVec not used
+    ballPosDiff.unit(ballUnitVec);
+    console.log('ball.velocity', ball.velocity);
+// IF BALL IS MOVING AWAY FROM FLIPPER, DO NOTHING
+    if (ball.velocity.z < 0) return;
+// GET THE TANGENT VECTOR OF THE CURRENT FLIPPER ORIENTATION - 'UP' OR 'DOWN'
+    const tangentCollisionVector = flipperStateRef.tangentCollisionVector[flipperStateRef.orientation];
+    const maxVelocity = 5;
+    const magnitude = {
+      x: Math.abs(ballUnitVec.x),
+      z: Math.abs(ballUnitVec.z)
+    }
+    const velocity = new CANNON.Vec3(
+      tangentCollisionVector.x * maxVelocity, //* magnitude.x,
+      -ballPosDiff.y,
+      tangentCollisionVector.z * maxVelocity //+ magnitude.z
+    );
+    ball.velocity.set(...Object.values(velocity));
+  }
+}
+
 
 Flipper.prototype.onFlipperUp = function () {
   this.getCollisionFrame();
-  this.isAnimating = true;
+  this.flipperState.isAnimating = true;
+  this.flipperState.orientation = 'up';
   this.animationFrame = -1;
   this.animationDirection = 1;
   this.animationStopAfterFrame = this.animation.length - 1;
 }
 
 Flipper.prototype.onFlipperDown = function () {
-  this.isAnimating = true;
+  this.flipperState.isAnimating = true;
+  this.flipperState.orientation = 'down';
   this.animationFrame = this.animation.length - 1;
   this.animationDirection = -1;
   this.animationStopAfterFrame = 0;
 }
 
+
 // REQUEST ANIM FRAME LOOP
 Flipper.prototype.step = function () {
+  if (this.flipperState.isAnimating === false) return; 
   const { position, previousPosition } = this.ballRef;
-  if (this.isAnimating === false) return; 
 // BEGIN FRAME
   this.animationFrame += this.animationDirection;
 // UPDATE FLIPPER POSITION
   this.body.quaternion.copy(this.animation[this.animationFrame]);
 // CHECK IF COLLISION FRAME
   if (this.animationFrame === this.collisionFrame.frame) {
-    console.log('this.collisionFrame', this.collisionFrame)
-    console.log('this.collisionFrame.velocity', this.collisionFrame.velocity);
     this.ballRef.velocity.set(...Object.values(this.collisionFrame.velocity));
-    this.collisionFrame === -1;
+    this.collisionFrame.frame = -1;
   }
 // CHECK IF LAST ANIMATION FRAME HAS BEEN RENDERED
   if (this.animationFrame === this.animationStopAfterFrame) {
-    this.isAnimating = false;
+    this.flipperState.isAnimating = false;
   }
 }
 
 
 Flipper.prototype.createBody = function ({ world }) {length
-  const shape = new CANNON.Box(new CANNON.Vec3(2, 0.4, 0.1));
+  const shape = new CANNON.Box(new CANNON.Vec3(2, 0.4, 0.2));
   const body = new CANNON.Body({
     mass: 0,
     isTrigger: true,
-    position: this.flipperPos
+    position: this.flipperPos,
+    collisionFilterGroup: COLLISION_GROUPS.FLIPPER
   });
   body.addShape(shape, this.shapeOffset);
   world.addBody(body);
@@ -136,7 +198,7 @@ Flipper.prototype.getCollisionFrame = function () {
   const ballPos = new CANNON.Vec3(...Object.values(position));
   const ballPosDiff = new CANNON.Vec3();
   ballPos.vsub(ballPrevPos, ballPosDiff);
-  const ballUnitVec = new CANNON.Vec3();
+  const ballUnitVec = new CANNON.Vec3(); // ballUnitVec not used
   ballPosDiff.unit(ballUnitVec);
 
   for (let frame = 1; frame < this.hitAreas.length; frame++) {
@@ -152,47 +214,39 @@ Flipper.prototype.getCollisionFrame = function () {
 // ANGLE BETWEEN BALL CENTER, FLIPPER PIVOT, AND BALL CONTACT POINT
     const angleBetweenCenterAndContactPoint = Math.asin(this.ballRadius/distanceFromCenter);
 // TARGET FLIPPER ANGLE FOR HIT AREA TEST
-console.log(`angleFromCenter: ${radToDeg(angleFromCenter)}, angleBetweenCenterAndContactPoint: ${radToDeg(angleBetweenCenterAndContactPoint)}`)
     const targetAngleForHitAreaTest = this.name === 'leftFlipper' 
       ? angleFromCenter - angleBetweenCenterAndContactPoint
       : angleFromCenter + angleBetweenCenterAndContactPoint
-console.log('targetAngleForHitAreaTest', radToDeg(targetAngleForHitAreaTest))
     const { min, max } = this.hitAreas[frame];
-console.log('')
-console.log(`frame ${frame}: test if ${radToDeg(targetAngleForHitAreaTest)} < ${min * 180/Math.PI} || ${targetAngleForHitAreaTest * 180/Math.PI} > ${max * 180/Math.PI}`)
 
-  let velocity;
-  if (this.name === 'leftFlipper') {
-    if (targetAngleForHitAreaTest < min || targetAngleForHitAreaTest > max ) continue;
-    const tangentVelocity = {
-      x: -Math.sin(targetAngleForHitAreaTest),
-      z: -Math.cos(targetAngleForHitAreaTest)
+    let velocity;
+    if (this.name === 'leftFlipper') {
+      if (targetAngleForHitAreaTest < min || targetAngleForHitAreaTest > max ) continue;
+      const tangentVelocity = {
+        x: -Math.sin(targetAngleForHitAreaTest),
+        z: -Math.cos(targetAngleForHitAreaTest)
+      }
+      const flipperMagnitude = distanceFromCenter / this.flipperLengthFromPivot;
+      velocity = new CANNON.Vec3(
+        tangentVelocity.x * this.maxVelocity * flipperMagnitude,
+        -ballPosDiff.y,
+        tangentVelocity.z * this.maxVelocity * flipperMagnitude
+      );
     }
-    console.log('*****tangentVelocity', tangentVelocity)
-    console.log('')
-    const flipperMagnitude = distanceFromCenter / this.flipperLengthFromPivot;
-    velocity = new CANNON.Vec3(
-      tangentVelocity.x * this.maxVelocity * flipperMagnitude,
-      -ballPosDiff.y,
-      tangentVelocity.z * this.maxVelocity * flipperMagnitude
-    );
-  }
 
-  if (this.name === 'rightFlipper') {
-    if (targetAngleForHitAreaTest > min || targetAngleForHitAreaTest < max ) continue;
-    const tangentVelocity = {
-      x: Math.sin(targetAngleForHitAreaTest),
-      z: Math.cos(targetAngleForHitAreaTest)
+    if (this.name === 'rightFlipper') {
+      if (targetAngleForHitAreaTest > min || targetAngleForHitAreaTest < max ) continue;
+      const tangentVelocity = {
+        x: Math.sin(targetAngleForHitAreaTest),
+        z: Math.cos(targetAngleForHitAreaTest)
+      }
+      const flipperMagnitude = distanceFromCenter / this.flipperLengthFromPivot;
+      velocity = new CANNON.Vec3(
+        tangentVelocity.x * this.maxVelocity * flipperMagnitude,
+        -ballPosDiff.y,
+        tangentVelocity.z * this.maxVelocity * flipperMagnitude
+      );
     }
-    console.log('*****tangentVelocity', tangentVelocity)
-    console.log('')
-    const flipperMagnitude = distanceFromCenter / this.flipperLengthFromPivot;
-    velocity = new CANNON.Vec3(
-      tangentVelocity.x * this.maxVelocity * flipperMagnitude,
-      -ballPosDiff.y,
-      tangentVelocity.z * this.maxVelocity * flipperMagnitude
-    );
-  }
 
     this.collisionFrame = {
       frame,


### PR DESCRIPTION
Why: When flipper is animated, the predictive collision method dictates the ball's response. When the flipper is static, the ball passes through the flipper.

Added a method to identify 'static flipper' collisions and assign the corresponding 'up' or 'down' flipper dynamic to the ball's response.