### PR TITLE
triangular flipper collision prediction @PRX-008

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import CannonDebugger from 'cannon-es-debugger';
 import Stats from 'stats.js';
 // Objects
-import Flipper from './cannon/objects/Flipper';
+import { WedgeFlipper } from './cannon/objects/WedgeFlipper';
 import KeyEvents from './inputEvents';
 
 
@@ -44,8 +44,8 @@ ballBody.velocity.z = 6;
 ballBody.addShape(ballShape);
 world.addBody(ballBody);
 // ADD FLIPPERS 
-const leftFlipper = new Flipper({ name: 'leftFlipper',  world, ballRef: ballBody });
-const rightFlipper = new Flipper({ name: 'rightFlipper',  world, ballRef: ballBody });
+const leftFlipper = new WedgeFlipper({ world, side: 'left', ballRef: ballBody });
+const rightFlipper = new WedgeFlipper({ world, side: 'right', ballRef: ballBody });
 // DEV/DEBUG HELPERS
 const cannonDebugger = new CannonDebugger(scene, world);
 const controls = new OrbitControls(camera, renderer.domElement);

--- a/src/cannon/objects/Flipper/configs/index.js
+++ b/src/cannon/objects/Flipper/configs/index.js
@@ -1,0 +1,105 @@
+import * as CANNON from 'cannon-es';
+import { COLLISION_GROUPS } from '../../../collisions';
+
+
+export const initFlipper = {
+  flipperLengthFromPivot: 3.5,
+  maxVelocity: 90,
+// CREATE BODY 
+  position: {
+    left: new CANNON.Vec3(-4, 0.3, -1),
+    right: new CANNON.Vec3(4, 0.3, -1)
+  },
+  shape: new CANNON.Box(new CANNON.Vec3(2, 0.4, 0.2)),
+  shapeOffset: new CANNON.Vec3(1.5, 0, 0),
+  CREATE_BODY ({ world, side }) {
+    const body = new CANNON.Body({
+      mass: 0,
+      isTrigger: true,
+      position: this.position[side],
+      collisionFilterGroup: COLLISION_GROUPS.FLIPPER
+    });
+    body.addShape(this.shape, this.shapeOffset);
+    world.addBody(body);
+    return body;
+  },
+// CREATE ANIMATION
+  startRadian: {
+    left: -Math.PI/6,
+    right: Math.PI + Math.PI/6
+  },
+  endRadian : {
+    left: Math.PI/4,
+    right: Math.PI - Math.PI/4
+  },
+  animSteps: 4,
+  CREATE_ANIMATION ({ side }) {
+    const startRadian = this.startRadian[side];
+    const endRadian = this.endRadian[side];
+    const quat = new CANNON.Quaternion();
+    quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), startRadian);
+    //this.body.quaternion.copy(quat);
+    const increment = (endRadian - startRadian) / this.animSteps;
+    const animation = [];
+    const flipperAngles = []
+    for (let frame = 0; frame <= this.animSteps; frame++) {
+      const flipperAngle = startRadian + frame * increment;
+      flipperAngles.push(flipperAngle);
+      const quat = new CANNON.Quaternion();
+      quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), flipperAngle);
+      animation.push(quat);
+    }
+    const hitAreas = flipperAngles.map((angle, idx) => {
+      const hitArea = { min: null, max: null, minDegrees: null, maxDegrees: null };
+      if (idx > 0) {
+        hitArea.min = flipperAngles[idx-1];
+        hitArea.max = flipperAngles[idx];
+        hitArea.minDegrees = flipperAngles[idx-1] * 180/Math.PI;
+        hitArea.maxDegrees = flipperAngles[idx] * 180/Math.PI;
+      }
+      return hitArea;
+    })
+    return { animation, hitAreas };
+  },
+  SET_FLIPPER_STATE ({ side }) {
+    const startRadian = this.startRadian[side];
+    const endRadian = this.endRadian[side];
+    const mirrorValue = side === 'left' ? -1 : 1;
+    return {
+      isAnimating: false,
+      orientation: 'down',
+      tangentCollisionVector: { 
+        up: { 
+          x: Math.sin(endRadian) * mirrorValue,
+          z: Math.cos(endRadian) * mirrorValue
+        },
+        down: {
+          x: Math.sin(startRadian) * mirrorValue,
+          z: Math.cos(startRadian) * mirrorValue
+        }
+      }
+    }
+  },
+  SET_STEP_STATE () {
+    return {
+      frame: null,
+      direction: 1,
+      endFrame: null
+    }
+  },
+  SET_COLLISION_STATE ({ side }) {
+    return {
+      side,
+      position: this.position[side],
+      flipperLengthFromPivot: this.flipperLengthFromPivot,
+      maxVelocity: this.maxVelocity,
+      impact: { frame: null, velocity: {}}
+    }
+  },
+  SET_BALL_STATE ({ ballRef }) {
+    return {
+      ref: ballRef,
+      radius: ballRef.shapes[0].radius
+    }
+  }
+}

--- a/src/cannon/objects/WedgeFlipper/configs/index.js
+++ b/src/cannon/objects/WedgeFlipper/configs/index.js
@@ -1,0 +1,158 @@
+import * as CANNON from 'cannon-es';
+import { COLLISION_GROUPS } from '../../../collisions';
+import { CannonBox, CannonWedge } from '../../../shapes';
+
+
+export const initFlipper = {
+  flipperLengthFromPivot: 4,
+  maxVelocity: 90,
+// CREATE BODY 
+  position: {
+    left: new CANNON.Vec3(-4, 0.3, -1),
+    right: new CANNON.Vec3(4, 0.3, -1)
+  },
+  shape: CannonWedge({ widthX: 2, heightY: 0.4, depthZ: 0.5 }),
+  shapeOffset: new CANNON.Vec3(2, 0, 0),
+  CREATE_BODY ({ world, side }) {
+    console.log('CREAte Body')
+    const body = new CANNON.Body({
+      mass: 0,
+      isTrigger: true,
+      position: this.position[side],
+      collisionFilterGroup: COLLISION_GROUPS.FLIPPER
+    });
+    body.addShape(this.shape, this.shapeOffset);
+    world.addBody(body);
+    return body;
+  },
+// CREATE ANIMATION
+  startRadian: {
+    left: -Math.PI/6,
+    right: Math.PI + Math.PI/6
+  },
+  endRadian : {
+    left: Math.PI/4,
+    right: Math.PI - Math.PI/4
+  },
+  animSteps: 4,
+  CREATE_ANIMATION ({ side }) {
+    const startRadian = this.startRadian[side];
+    const endRadian = this.endRadian[side];
+    const quat = new CANNON.Quaternion();
+    quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), startRadian);
+    //this.body.quaternion.copy(quat);
+    const increment = (endRadian - startRadian) / this.animSteps;
+    const animation = [];
+    const flipperAngles = []
+    for (let frame = 0; frame <= this.animSteps; frame++) {
+      const flipperAngle = startRadian + frame * increment;
+      flipperAngles.push(flipperAngle);
+      const quat = new CANNON.Quaternion();
+      quat.setFromAxisAngle(new CANNON.Vec3( 0, 1, 0 ), flipperAngle);
+      animation.push(quat);
+    }
+    const hitAreas = flipperAngles.map((angle, idx) => {
+      const hitArea = { min: null, max: null, minDegrees: null, maxDegrees: null };
+      if (idx > 0) {
+        hitArea.min = flipperAngles[idx-1];
+        hitArea.max = flipperAngles[idx];
+        hitArea.minDegrees = flipperAngles[idx-1] * 180/Math.PI;
+        hitArea.maxDegrees = flipperAngles[idx] * 180/Math.PI;
+      }
+      return hitArea;
+    })
+    return { animation, hitAreas };
+  },
+  SET_FLIPPER_STATE ({ side }) {
+    const startRadian = this.startRadian[side];
+    const endRadian = this.endRadian[side];
+    const mirrorValue = side === 'left' ? -1 : 1;
+    return {
+      isAnimating: false,
+      orientation: 'down',
+      tangentCollisionVector: { 
+        up: { 
+          x: Math.sin(endRadian) * mirrorValue,
+          z: Math.cos(endRadian) * mirrorValue
+        },
+        down: {
+          x: Math.sin(startRadian) * mirrorValue,
+          z: Math.cos(startRadian) * mirrorValue
+        }
+      }
+    }
+  },
+  SET_STEP_STATE () {
+    return {
+      frame: null,
+      direction: 1,
+      endFrame: null
+    }
+  },
+  SET_COLLISION_STATE ({ side }) {
+    return {
+      side,
+      position: this.position[side],
+      flipperLengthFromPivot: this.flipperLengthFromPivot,
+      maxVelocity: this.maxVelocity,
+      impact: { frame: null, velocity: {}}
+    }
+  },
+  SET_BALL_STATE ({ ballRef }) {
+    return {
+      ref: ballRef,
+      radius: ballRef.shapes[0].radius
+    }
+  },
+  GET_FLIPPER_ANGLE_OF_CONTACT ({
+    ball,
+    flipper,
+    side
+    }) {
+      const distance = {
+        pivotToBallCenter: undefined,
+        pivotToBallSurface: undefined,
+        wedgeCenterToBallSurface: undefined
+      }
+      const angle = {
+        pivotToBallCenter: undefined,
+        ballCenterToPivotToBallSurface: undefined,
+        ballSurfaceToPivotToWedgeCenter: undefined,
+        flipperRotationAtPointOfContact: undefined,
+        flipperAngleOfContact: undefined
+      }
+
+      // STEP 1
+        distance.pivotToBallCenter = Math.sqrt(Math.pow(ball.position.x - flipper.axis.x, 2) + Math.pow(ball.position.z - flipper.axis.z, 2));
+  console.log('STEP 1: distance.pivotToBallCenter', distance.pivotToBallCenter)
+      // STEP 2
+        angle.pivotToBallCenter = Math.atan((ball.position.z - flipper.axis.z) / (ball.position.x - flipper.axis.x));
+        if (side === 'right') angle.pivotToBallCenter += Math.PI;
+  console.log('STEP 2: angle.pivotToBallCenter', angle.pivotToBallCenter)
+      // STEP 3
+        angle.ballCenterToPivotToBallSurface = Math.atan(ball.radius / distance.pivotToBallCenter);
+  console.log('STEP 3: angle.ballCenterToPivotToBallSurface', angle.ballCenterToPivotToBallSurface)
+      // STEP 4
+        distance.pivotToBallSurface = Math.abs(ball.radius / Math.sin(angle.ballCenterToPivotToBallSurface));
+  console.log('STEP 4: distance.pivotToBallSurface ', distance.pivotToBallSurface )
+      // STEP 5
+        distance.wedgeCenterToBallSurface = (flipper.length - distance.pivotToBallSurface) / flipper.length * flipper.wedgeBaseHeight;
+  console.log('STEP 5: distance.wedgeCenterToBallSurface  ', distance.wedgeCenterToBallSurface)
+      // STEP 6
+        angle.ballSurfaceToPivotToWedgeCenter = Math.asin(distance.wedgeCenterToBallSurface / distance.pivotToBallSurface);
+  console.log('--angle.ballSurfaceToPivotToWedgeCenter ', angle.ballSurfaceToPivotToWedgeCenter )
+      // STEP 7
+        angle.flipperRotationAtPointOfContact = side === 'left' ?
+          angle.pivotToBallCenter - angle.ballCenterToPivotToBallSurface - angle.ballSurfaceToPivotToWedgeCenter
+        : angle.pivotToBallCenter + angle.ballCenterToPivotToBallSurface + angle.ballSurfaceToPivotToWedgeCenter;
+        console.log('angle.flipperRotationAtPointOfContact', angle.flipperRotationAtPointOfContact)
+      // STEP 8
+        angle.flipperAngleOfContact = side === 'right' ?
+          angle.flipperRotationAtPointOfContact - flipper.wedgeSlope
+        : angle.flipperRotationAtPointOfContact + flipper.wedgeSlope;
+
+      return {  flipperRotationAtPointOfContact: angle.flipperRotationAtPointOfContact, 
+                flipperAngleOfContact: angle.flipperAngleOfContact,
+                distanceFromCenter: distance.pivotToBallCenter }
+  }
+}

--- a/src/cannon/shapes/CannonBox.js
+++ b/src/cannon/shapes/CannonBox.js
@@ -1,0 +1,38 @@
+import * as CANNON from 'cannon-es'
+
+
+////////////////
+// @param
+// @param
+export const CannonBox = ({ 
+  widthX,
+  heightY,
+  depthZ }) => {
+  const vertices = [
+    -1 * widthX,  1 * heightY, -1 * depthZ, // 0
+    -1 * widthX,  1 * heightY,  1 * depthZ, // 1
+    -1 * widthX, -1 * heightY,  1 * depthZ, // 2
+    -1 * widthX, -1 * heightY, -1 * depthZ, // 3
+     1 * widthX,  1 * heightY, -1 * depthZ, // 4
+     1 * widthX,  1 * heightY,  1 * depthZ, // 5
+     1 * widthX, -1 * heightY,  1 * depthZ, // 6
+     1 * widthX, -1 * heightY, -1 * depthZ, // 7
+  ];
+
+  const indices = [
+    0, 1, 2, // left
+    2, 3, 0, // left
+    0, 1, 5, // top
+    5, 4, 0, // top
+    4, 5, 6, // right
+    6, 7, 4, // right
+    2, 3, 7, // bottom
+    7, 6, 2, // bottom
+    0, 3, 7, // back
+    7, 4, 0, // back
+    1, 2, 6, // front
+    6, 5, 1, // front
+  ];
+
+  return new CANNON.Trimesh(vertices, indices);
+}

--- a/src/cannon/shapes/CannonWedge.js
+++ b/src/cannon/shapes/CannonWedge.js
@@ -1,0 +1,38 @@
+import * as CANNON from 'cannon-es'
+
+
+////////////////
+// @param
+// @param
+export const CannonWedge = ({ 
+  widthX,
+  heightY,
+  depthZ }) => {
+  const vertices = [
+    -1 * widthX,  1 * heightY, -1 * depthZ, // 0
+    -1 * widthX,  1 * heightY,  1 * depthZ, // 1
+    -1 * widthX, -1 * heightY,  1 * depthZ, // 2
+    -1 * widthX, -1 * heightY, -1 * depthZ, // 3
+     1 * widthX,  1 * heightY, -0.1 * depthZ, // 4
+     1 * widthX,  1 * heightY,  0.1 * depthZ, // 5
+     1 * widthX, -1 * heightY,  0.1 * depthZ, // 6
+     1 * widthX, -1 * heightY, -0.1 * depthZ, // 7
+  ];
+
+  const indices = [
+    0, 1, 2, // left
+    2, 3, 0, // left
+    0, 1, 5, // top
+    5, 4, 0, // top
+    4, 5, 6, // right
+    6, 7, 4, // right
+    2, 3, 7, // bottom
+    7, 6, 2, // bottom
+    0, 3, 7, // back
+    7, 4, 0, // back
+    1, 2, 6, // front
+    6, 5, 1, // front
+  ];
+
+  return new CANNON.Trimesh(vertices, indices);
+}

--- a/src/cannon/shapes/index.js
+++ b/src/cannon/shapes/index.js
@@ -1,2 +1,4 @@
 export { CannonCurve } from './CannonCurve';
 export { CannonRect } from './CannonRect';
+export { CannonBox } from './CannonBox';
+export { CannonWedge } from './CannonWedge';


### PR DESCRIPTION
Why: current 'paddle' flippers do reflect pinball's triangular 'wedge' flippers.

Create custom CannonTrimesh wedge shape function and updated collision prediction to account for slope of wedge relative to the flipper's angle of rotation.