### PR TITLE
add bumpers to playfield @PXR-010

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import CannonDebugger from 'cannon-es-debugger';
 import Stats from 'stats.js';
 // Objects
-import { WedgeFlipper, Ball, Playfield } from './cannon/objects';
+import { WedgeFlipper, Ball, Playfield, Bumper } from './cannon/objects';
 import KeyEvents from './inputEvents';
 // Collison groups
 import { COLLISION_GROUPS } from './cannon/collisions';
@@ -16,6 +16,7 @@ import { COLLISION_GROUPS } from './cannon/collisions';
 const world = new CANNON.World();
 world.gravity.set(0, -30, 0);
 world.broadphase = new CANNON.NaiveBroadphase();
+
 // INIT THREE JS
 const scene = new THREE.Scene()
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
@@ -23,14 +24,21 @@ camera.position.set(0, 15, 5);
 const renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
+
 // ADD PLAYFIELD
 const playField = new Playfield({ world });
+
+// ADD BUMPERS
+const bumpers = Bumper({ world });
+
 // ADD BALL
 const ball = new Ball({ world });
 ball.spawn();
+
 // ADD FLIPPERS 
 const leftFlipper = new WedgeFlipper({ world, side: 'left', ballRef: ball.bodyRef() });
 const rightFlipper = new WedgeFlipper({ world, side: 'right', ballRef: ball.bodyRef() });
+
 // DEV/DEBUG HELPERS
 const cannonDebugger = new CannonDebugger(scene, world);
 const controls = new OrbitControls(camera, renderer.domElement);
@@ -39,6 +47,7 @@ stats.showPanel(0);
 document.body.appendChild(stats.dom);
 const axesHelper = new THREE.AxesHelper( 5 );
 scene.add( axesHelper );
+
 // KEYBOARD INPUT
 const keyEvents = new KeyEvents();
 keyEvents.addSubscriber({ 
@@ -61,6 +70,7 @@ keyEvents.addSubscriber({
   keyAction: 'keyup',
   callBack: rightFlipper.onFlipperDown
   });
+
 // INIT ANIMATION VALUES
 const clock = new THREE.Clock();
 let delta;
@@ -86,7 +96,8 @@ animate();
 
 
 // HELPERS
-window.addEventListener('resize', onWindowResize, false)
+window.addEventListener('resize', onWindowResize, false);
+
 function onWindowResize() {
     camera.aspect = window.innerWidth / window.innerHeight
     camera.updateProjectionMatrix()

--- a/src/cannon/objects/Bumper/config/index.js
+++ b/src/cannon/objects/Bumper/config/index.js
@@ -3,6 +3,7 @@ import { bumperMaterial } from '../../../materials';
 import { quaternionPlayfieldSlope } from '../../../constants';
 import { bumperCollisionHandler, COLLISION_GROUPS } from 'cannon/collisions';
 
+const bodyOffsetX = 0.45; 
 export const BUMPER_CONFIG = {
   collisionFilterGroup: COLLISION_GROUPS.PLAYFIELD,
   material: bumperMaterial,
@@ -21,23 +22,18 @@ export const BUMPER_CONFIG = {
   ),
   locations: [    
     {
-      bumperName: 'top_center_bumper',
-      offset: new CANNON.Vec3(0, 0.5, -5) ,
-      quaternion: quaternionPlayfieldSlope
-    },
-    {
       bumperName: 'upper_left_bumper',
-      offset: new CANNON.Vec3(-2, 0.5, -3),
+      offset: new CANNON.Vec3(-2 + bodyOffsetX, 0.5, -5),
       quaternion: quaternionPlayfieldSlope
     },
     {
       bumperName: 'upper_right_bumper',
-      offset: new CANNON.Vec3(2, 0.5, -  3),
+      offset: new CANNON.Vec3(2 + bodyOffsetX, 0.5, -5),
       quaternion: quaternionPlayfieldSlope
     },
     {
-      bumperName: 'lower_right_bumper',
-      offset: new CANNON.Vec3(2, 0.5, 2 ),
+      bumperName: 'lower_center_bumper',
+      offset: new CANNON.Vec3(0  + bodyOffsetX, 0.5, -2),
       quaternion: quaternionPlayfieldSlope
     }
   ]

--- a/src/cannon/objects/Bumper/index.js
+++ b/src/cannon/objects/Bumper/index.js
@@ -1,8 +1,7 @@
 import * as CANNON from 'cannon-es'
 import { BUMPER_CONFIG } from './config';
 
-export const BumperBodies = (props) => {
-  const { world } = props;
+export const Bumper = ({ world }) => {
   const bumperBodies = {};
   const {
     shapeProps,

--- a/src/cannon/objects/index.js
+++ b/src/cannon/objects/index.js
@@ -1,3 +1,4 @@
 export { WedgeFlipper } from './WedgeFlipper';
 export { Ball } from './Ball';
 export { Playfield } from './Playfield';
+export { Bumper } from './Bumper';


### PR DESCRIPTION
Why: testing flipper dynamics by incrementally adding playfield objects.

The bumper object is assigned a collision event script that assigns a velocity vector to the ball based on the contact point and the bumper's center.