### PR TITLE
dynamic shooter land collision body @PXR-014

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import CannonDebugger from 'cannon-es-debugger';
 import Stats from 'stats.js';
 // Objects
-import { WedgeFlipper, Ball, Playfield, Bumper } from './cannon/objects';
+import { WedgeFlipper, Ball, Playfield, Bumper, ShooterLane } from './cannon/objects';
 import KeyEvents from './inputEvents';
 // Contact Materials
 import { initContactMaterials } from './cannon/materials';
@@ -20,13 +20,17 @@ world.broadphase = new CANNON.NaiveBroadphase();
 // INIT THREE JS
 const scene = new THREE.Scene()
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
-camera.position.set(0, 6, 15);
+camera.position.set(0, 10, 14);
 const renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
 
 // ADD PLAYFIELD
 const playField = new Playfield({ world });
+
+// ADD SHOOTER LANE
+const shooterLane = new ShooterLane({ world });
+setTimeout(shooterLane.onClose, 3000);
 
 // ADD BUMPERS
 const bumpers = Bumper({ world });
@@ -78,7 +82,7 @@ keyEvents.addSubscriber({
 const clock = new THREE.Clock();
 let delta;
 const timeStep = 1/60;
-const maxSubSteps = 5;
+const maxSubSteps = 10;
 // ANIMATION LOOP
 function animate() {
   stats.begin();

--- a/src/cannon/collisions/index.js
+++ b/src/cannon/collisions/index.js
@@ -16,7 +16,7 @@ export const bumperCollisionHandler = (e) => {
     x:xBumper, 
     y:yBumper, 
     z:zBumper } = e.target.shapeOffsets[0];
-  const impulseScaler = 40;
+  const impulseScaler = 30;
   const impulse = new CANNON.Vec3(
      (xBall - xBumper) * impulseScaler, 
       yBall, 

--- a/src/cannon/constants.js
+++ b/src/cannon/constants.js
@@ -1,7 +1,21 @@
 import * as CANNON from 'cannon-es';
 
-// SLOPE OF PINBALL PLAYFIELD
-export const PLAYFIELD_SLOPE_RADIANS = Math.PI/180 * 6;
-export const quaternionPlayfieldSlope = new CANNON.Quaternion();
-quaternionPlayfieldSlope.setFromAxisAngle(new CANNON.Vec3( 1, 0, 0 ), PLAYFIELD_SLOPE_RADIANS);
 
+export const PLAYFIELD_CONSTANTS = {
+  slopeRadians: Math.PI/180 * 6,
+  get slopeCos () { return Math.cos(this.slopeRadians) },
+  get slopeSin () { return Math.sin(this.slopeRadians) },
+  get slopeQuaternion () {  return getQuaternion({x: 1, y: 0, z: 0 }, this.slopeRadians) },
+  offsetX: 0.45,
+  outLaneRadians: Math.PI/180 * 16,
+  get leftOutLaneQuaternion () { return getQuaternion({x: 0, y: 1, z: 0 }, -this.outLaneRadians) },
+  get rightOutLaneQuaternion () { return getQuaternion({x: 0, y: 1, z: 0 }, this.outLaneRadians) },
+}
+
+
+
+function getQuaternion ({x, y, z}, radians) {
+  const quaternion = new CANNON.Quaternion();
+  quaternion.setFromAxisAngle(new CANNON.Vec3(x, y, z), radians);
+  return quaternion;
+}

--- a/src/cannon/objects/Ball/config/index.js
+++ b/src/cannon/objects/Ball/config/index.js
@@ -1,11 +1,13 @@
 import * as CANNON from 'cannon-es';
 import { COLLISION_GROUPS } from 'cannon/collisions';
 import { ballMaterial } from 'cannon/materials';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
+const offsetX = 0.45; // move to constants
 
 export const BALL_CONFIG = {
   mass: 15,
   radius: 0.25,
-  position: new CANNON.Vec3(0, 0, 0), 
+  position: new CANNON.Vec3(4.75 + offsetX, -PLAYFIELD_CONSTANTS.slopeSin * 9.75 + 0.25, PLAYFIELD_CONSTANTS.slopeCos * 9.75), 
   material: ballMaterial,
   collisionFilterGroup: COLLISION_GROUPS.BALL,
   collisionFilterMask: COLLISION_GROUPS.PLAYFIELD | COLLISION_GROUPS.FLIPPER

--- a/src/cannon/objects/Ball/index.js
+++ b/src/cannon/objects/Ball/index.js
@@ -26,8 +26,7 @@ export function Ball ({ world }) {
 }
 
 Ball.prototype.spawn = function () {
-  this.body.velocity.x = - 9 - Math.random() * 2;
-  this.body.velocity.z = 6;
+  this.body.velocity.z = 30;
 }
 
 Ball.prototype.bodyRef = function () {

--- a/src/cannon/objects/Bumper/config/index.js
+++ b/src/cannon/objects/Bumper/config/index.js
@@ -1,7 +1,8 @@
 import * as CANNON from 'cannon-es';
 import { bumperMaterial } from '../../../materials';
-import { quaternionPlayfieldSlope } from '../../../constants';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
 import { bumperCollisionHandler, COLLISION_GROUPS } from 'cannon/collisions';
+import { PlaneBufferGeometry } from 'three';
 
 const bodyOffsetX = 0.45; 
 export const BUMPER_CONFIG = {
@@ -24,17 +25,17 @@ export const BUMPER_CONFIG = {
     {
       bumperName: 'upper_left_bumper',
       offset: new CANNON.Vec3(-2 + bodyOffsetX, 0.5, -5),
-      quaternion: quaternionPlayfieldSlope
+      quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     },
     {
       bumperName: 'upper_right_bumper',
       offset: new CANNON.Vec3(2 + bodyOffsetX, 0.5, -5),
-      quaternion: quaternionPlayfieldSlope
+      quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     },
     {
       bumperName: 'lower_center_bumper',
       offset: new CANNON.Vec3(0  + bodyOffsetX, 0.5, -2),
-      quaternion: quaternionPlayfieldSlope
+      quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     }
   ]
 }

--- a/src/cannon/objects/Playfield/config/index.js
+++ b/src/cannon/objects/Playfield/config/index.js
@@ -1,19 +1,19 @@
 import * as CANNON from 'cannon-es';
 import { playFieldMaterial } from 'cannon/materials';
-import { CannonCurve, CannonRect, CannonOrbit } from 'cannon/shapes';
-import { quaternionPlayfieldSlope } from 'cannon/constants';
+import { CannonRect, CannonCurve, CannonOrbit } from 'cannon/shapes';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
 import { COLLISION_GROUPS } from 'cannon/collisions';
 
-const offsetX = 0.45;
+
 export const PLAYFIELD_CONFIG = {
-  quaternionPlayfieldSlope,
+  quaternionPlayfieldSlope: PLAYFIELD_CONSTANTS.slopeQuaternion,
   collisionGroup: COLLISION_GROUPS.PLAYFIELD,
   playFieldMaterial,
   compositeElements: [
     {
       descripiton: 'Orbit',
       props: {
-        offset: new CANNON.Vec3(0 + offsetX, 0, -5),
+        offset: new CANNON.Vec3(0 + PLAYFIELD_CONSTANTS.offsetX, 0, -5),
         radius: 5,
         height: 1,
         radialSegments: 32,
@@ -31,18 +31,18 @@ export const PLAYFIELD_CONFIG = {
       ySize: 0,
       zSize: 20
     },
-    offset: new CANNON.Vec3(0 + offsetX, 0, 0),
+    offset: new CANNON.Vec3(0 + PLAYFIELD_CONSTANTS.offsetX, 0, 0),
     computeShape: (props) => CannonRect(props)
   },
 
   {
     description: 'Ceiling',
     props: {
-      xSize: 10,
+      xSize: 11,
       ySize: .5,
       zSize: 20
     },
-    offset: new CANNON.Vec3(0 + offsetX, 1.25, 0),
+    offset: new CANNON.Vec3(0 + PLAYFIELD_CONSTANTS.offsetX, 1.25, 0),
     computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
   },   
   {
@@ -52,23 +52,9 @@ export const PLAYFIELD_CONFIG = {
       ySize: 1,
       zSize: .5
     },
-    offset: new CANNON.Vec3(0 + offsetX, 0.5, -10.25),
+    offset: new CANNON.Vec3(0 + PLAYFIELD_CONSTANTS.offsetX, 0.5, -10.25),
     computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
   },
-  /*
-  {
-    description: 'Top curved wall',
-    props: {
-      radius: 5,
-      height: 1,
-      radialSegments: 32,
-      thetaStart: 0,
-      thetaLength: -Math.PI * 1.2
-    },
-    offset: new CANNON.Vec3(0 + offsetX, 0, -5),
-    computeShape: (props) => CannonCurve(props)
-  },
-  */
   {
     description: 'left gutter',
     props: {
@@ -78,7 +64,7 @@ export const PLAYFIELD_CONFIG = {
       thetaStart: -Math.PI,
       thetaLength: -Math.PI * .30
     },
-    offset: new CANNON.Vec3(-3 + offsetX, 0, 4.75),
+    offset: new CANNON.Vec3(-3 + PLAYFIELD_CONSTANTS.offsetX, 0, 4.75),
     computeShape: (props) => CannonCurve(props)
   },
   {
@@ -90,18 +76,30 @@ export const PLAYFIELD_CONFIG = {
       thetaStart: 0,
       thetaLength: Math.PI * .30
     },
-    offset: new CANNON.Vec3(2.25 + offsetX, 0, 4.75),
+    offset: new CANNON.Vec3(2.25 + PLAYFIELD_CONSTANTS.offsetX, 0, 4.75),
     computeShape: (props) => CannonCurve(props)
   },
   {
-    description: 'Bottom wall',
+    description: 'bottom left outlane',
     props: {
-      xSize: 10,
+      xSize: 4,
       ySize: 1,
-      zSize: 0
+      zSize: 0.5
     },
-    offset: new CANNON.Vec3(0 + offsetX, 0.5, 10),
-    computeShape: (props) => CannonRect(props)
+    offset: new CANNON.Vec3(-3 + PLAYFIELD_CONSTANTS.offsetX, 0.5, 9.5),
+    quaternion: PLAYFIELD_CONSTANTS.leftOutLaneQuaternion,
+    computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
+  },
+  {
+    description: 'bottom right outlane',
+    props: {
+      xSize: 4,
+      ySize: 1,
+      zSize: 0.5
+    },
+    offset: new CANNON.Vec3(3 - PLAYFIELD_CONSTANTS.offsetX, 0.5, 9.5),
+    quaternion: PLAYFIELD_CONSTANTS.rightOutLaneQuaternion,
+    computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
   },
   {
     description: 'Left wall',
@@ -110,7 +108,7 @@ export const PLAYFIELD_CONFIG = {
       ySize: 1,
       zSize: 20
     },
-    offset: new CANNON.Vec3(-5.25 + offsetX, .5, 0),
+    offset: new CANNON.Vec3(-5.25 + PLAYFIELD_CONSTANTS.offsetX, .5, 0),
     computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
   },
   {
@@ -120,17 +118,7 @@ export const PLAYFIELD_CONFIG = {
       ySize: 1,
       zSize: 20
     },
-    offset: new CANNON.Vec3(5.25 + offsetX, .5, 0),
-    computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
-  },
-  {
-    description: 'Right wall',
-    props: {
-      xSize: 0.2,
-      ySize: 1,
-      zSize: 15
-    },
-    offset: new CANNON.Vec3(4.3 + offsetX, .5, 2.5),
+    offset: new CANNON.Vec3(5.25 + PLAYFIELD_CONSTANTS.offsetX, .5, 0),
     computeShape: (props) => new CANNON.Box(new CANNON.Vec3(props.xSize / 2, props.ySize / 2, props.zSize / 2))
   }
   ]

--- a/src/cannon/objects/Playfield/index.js
+++ b/src/cannon/objects/Playfield/index.js
@@ -10,9 +10,9 @@ export function Playfield ({ world }) {
     }
   );
   PLAYFIELD_CONFIG.elements.forEach(item => {
-    const { props, offset, computeShape } = item;
+    const { props, offset, quaternion, computeShape } = item;
     const shape = computeShape(props);
-    this.body.addShape(shape, offset)
+    this.body.addShape(shape, offset, quaternion)
     }
   );
 

--- a/src/cannon/objects/ShooterLane/config/index.js
+++ b/src/cannon/objects/ShooterLane/config/index.js
@@ -1,0 +1,37 @@
+import * as CANNON from 'cannon-es';
+import { playFieldMaterial } from 'cannon/materials';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
+import { COLLISION_GROUPS } from 'cannon/collisions';
+
+
+export const SHOOTER_LANE_CONFIGS = {
+  quaternionPlayfieldSlope: PLAYFIELD_CONSTANTS.slopeQuaternion,
+  playFieldMaterial,
+  collisionGroup: COLLISION_GROUPS.PLAYFIELD,
+  shapes: {
+    shooterLaneOpen: {
+      xSize: 0.2,
+      ySize: 1,
+      zSize: 15,
+      get halfExtents() { return new CANNON.Vec3(this.xSize/2, this.ySize/2, this.zSize/2) },
+      offset: new CANNON.Vec3(4.3 + PLAYFIELD_CONSTANTS.offsetX, .5, 2.5),
+      get shape() { return new CANNON.Box(this.halfExtents) }
+    },
+    shooterLaneClosed: {
+      xSize: 0.6,
+      ySize: 1,
+      zSize: 15,
+      get halfExtents() { return new CANNON.Vec3(this.xSize/2, this.ySize/2, this.zSize/2) },
+      offset: new CANNON.Vec3(4.7 + PLAYFIELD_CONSTANTS.offsetX, .5, 2.5),
+      get shape() { return new CANNON.Box(this.halfExtents) }
+    },
+    shooterLaneBottom: {
+      xSize: 1.1,
+      ySize: 1,
+      zSize: .5,
+      get halfExtents() { return new CANNON.Vec3(this.xSize/2, this.ySize/2, this.zSize/2) },
+      offset: new CANNON.Vec3(4.95 + PLAYFIELD_CONSTANTS.offsetX, .5, 10.25),
+      get shape() { return new CANNON.Box(this.halfExtents) }
+    }
+  }
+}

--- a/src/cannon/objects/ShooterLane/index.js
+++ b/src/cannon/objects/ShooterLane/index.js
@@ -1,0 +1,44 @@
+import * as CANNON from 'cannon-es';
+import { SHOOTER_LANE_CONFIGS } from './config';
+
+export function ShooterLane ({ world }) {
+  // BIND OBJECT FUNCTIONS
+  this.onOpen = this.onOpen.bind(this);
+  this.onClose = this.onClose.bind(this);
+  // SHOOTER LANE BODY
+  this.shooterLaneBody = new CANNON.Body({
+    mass: 0, 
+    material: SHOOTER_LANE_CONFIGS.playFieldMaterial ,
+    position: new CANNON.Vec3(0, 0, 0),
+    collisionFilterGroup: SHOOTER_LANE_CONFIGS.collisionGroup
+  });
+  // SHOOTER LANE SHAPES
+  const { shapes } = SHOOTER_LANE_CONFIGS;
+  const { shooterLaneOpen, shooterLaneClosed, shooterLaneBottom} = shapes;
+  this.lane = {
+    open: {
+      shape: shooterLaneOpen.shape,
+      offset: shooterLaneOpen.offset
+    },
+    closed: {
+      shape: shooterLaneClosed.shape,
+      offset: shooterLaneClosed.offset
+    }
+  }
+  this.shooterLaneBody.addShape(shooterLaneBottom.shape, shooterLaneBottom.offset);
+
+  // TILT OF PLAYFIELD
+  this.shooterLaneBody.quaternion.copy(SHOOTER_LANE_CONFIGS.quaternionPlayfieldSlope);
+  world.addBody(this.shooterLaneBody);
+  this.onOpen();
+}
+
+ShooterLane.prototype.onClose = function () {
+  this.shooterLaneBody.removeShape(this.lane.open.shape);
+  this.shooterLaneBody.addShape(this.lane.closed.shape, this.lane.closed.offset);
+}
+
+ShooterLane.prototype.onOpen = function () {
+  this.shooterLaneBody.removeShape(this.lane.closed.shape);
+  this.shooterLaneBody.addShape(this.lane.open.shape, this.lane.open.offset);
+}

--- a/src/cannon/objects/WedgeFlipper/configs/index.js
+++ b/src/cannon/objects/WedgeFlipper/configs/index.js
@@ -1,17 +1,17 @@
 import * as CANNON from 'cannon-es';
-import { COLLISION_GROUPS } from '../../../collisions';
-import { CannonWedge } from '../../../shapes';
+import { COLLISION_GROUPS } from 'cannon/collisions';
+import { CannonWedge } from 'cannon/shapes';
 import { createFlipperBody, getContactFrame } from '../helpers';
-import { PLAYFIELD_SLOPE_RADIANS } from '../../../constants';
-import { flipperMaterial } from '../../../materials';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
+import { flipperMaterial } from 'cannon/materials';
 
 export const initFlipper = {
   flipperLengthFromPivot: 4,
   flipperHeight: 0.8,
   wedgeBaseHeight: 0.5,
   flipperOffsetZ: 7,
-  get playFieldSlopeOffsetY() { return  Math.sin(PLAYFIELD_SLOPE_RADIANS) * this.flipperOffsetZ},
-  get playFieldSlipeOffsetZ() { return  Math.cos(PLAYFIELD_SLOPE_RADIANS) * this.flipperOffsetZ},
+  get playFieldSlopeOffsetY() { return  PLAYFIELD_CONSTANTS.slopeSin * this.flipperOffsetZ},
+  get playFieldSlipeOffsetZ() { return  PLAYFIELD_CONSTANTS.slopeCos * this.flipperOffsetZ},
   get wedgeSlope() { return Math.atan(this.wedgeBaseHeight / this.flipperLengthFromPivot)},
   maxVelocity: 60,
   get axis() { return {

--- a/src/cannon/objects/index.js
+++ b/src/cannon/objects/index.js
@@ -2,3 +2,4 @@ export { WedgeFlipper } from './WedgeFlipper';
 export { Ball } from './Ball';
 export { Playfield } from './Playfield';
 export { Bumper } from './Bumper';
+export { ShooterLane } from './ShooterLane';


### PR DESCRIPTION
Why: ball was passing through inner wall of shooter lane.

Inner shooter land wall expands after ball exits lane. The thicker wall body can better detect ball collisions at high speeds.