### PR TITLE
custom event for new ball after drain event @PXR-015

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,12 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import CannonDebugger from 'cannon-es-debugger';
 import Stats from 'stats.js';
 // Objects
-import { WedgeFlipper, Ball, Playfield, Bumper, ShooterLane } from './cannon/objects';
+import { WedgeFlipper, Ball, Playfield, Bumper, ShooterLane } from 'cannon/objects';
+// Triggers
+import { DrainTrigger } from 'cannon/triggers';
+// Custom EventTarget
+import { PXREvent, DRAIN_EVENT } from 'cannon/customEvents';
+// Input
 import KeyEvents from './inputEvents';
 // Contact Materials
 import { initContactMaterials } from './cannon/materials';
@@ -37,7 +42,7 @@ const bumpers = Bumper({ world });
 
 // ADD BALL
 const ball = new Ball({ world });
-ball.spawn();
+setTimeout(ball.spawn, 1000);
 
 // ADD FLIPPERS 
 const leftFlipper = new WedgeFlipper({ world, side: 'left', ballRef: ball.bodyRef() });
@@ -45,6 +50,17 @@ const rightFlipper = new WedgeFlipper({ world, side: 'right', ballRef: ball.body
 
 // INIT CONTACT MATERIALS
 initContactMaterials({ world });
+
+// ADD TRIGGERS
+const drainTrigger = new DrainTrigger({ world });
+drainTrigger.addCollideDispatch(() => PXREvent.dispatchEvent(DRAIN_EVENT));
+
+// LISTENERS
+PXREvent.addEventListener('DRAIN_EVENT', () => {
+  shooterLane.onOpen();
+  setTimeout(ball.spawn, 1000);
+  setTimeout(shooterLane.onClose, 4000);
+});
 
 // DEV/DEBUG HELPERS
 const cannonDebugger = new CannonDebugger(scene, world);

--- a/src/cannon/collisions/index.js
+++ b/src/cannon/collisions/index.js
@@ -3,7 +3,8 @@ import * as CANNON from 'cannon-es';
 export const COLLISION_GROUPS = {
   BALL: 1,
   PLAYFIELD: 2,
-  FLIPPER: 4
+  FLIPPER: 4,
+  TRIGGER: 5
 }
 
 
@@ -32,6 +33,3 @@ export const bumperCollisionHandler = (e) => {
   e.body.velocity.z = impulse.z;
 }
 
-export const lowerLimitFlipperCollisionHandler = (e) => {
-  e.target.constraintTarget.motorEquation.enabled = false;
-}

--- a/src/cannon/constants.js
+++ b/src/cannon/constants.js
@@ -19,3 +19,8 @@ function getQuaternion ({x, y, z}, radians) {
   quaternion.setFromAxisAngle(new CANNON.Vec3(x, y, z), radians);
   return quaternion;
 }
+
+
+
+export const PXREvent = new EventTarget();
+export const DRAIN_EVENT = new Event('DRAIN_EVENT'); // organize event definitions in dedicated config

--- a/src/cannon/customEvents.js
+++ b/src/cannon/customEvents.js
@@ -1,0 +1,2 @@
+export const PXREvent = new EventTarget();
+export const DRAIN_EVENT = new Event('DRAIN_EVENT');

--- a/src/cannon/objects/Ball/index.js
+++ b/src/cannon/objects/Ball/index.js
@@ -10,6 +10,7 @@ export function Ball ({ world }) {
     collisionFilterGroup,
     collisionFilterMask
   } = BALL_CONFIG;
+  this.position = position;
   this.spawn = this.spawn.bind(this);
   this.bodyRef = this.bodyRef.bind(this);
   this.body = new CANNON.Body({
@@ -26,7 +27,14 @@ export function Ball ({ world }) {
 }
 
 Ball.prototype.spawn = function () {
-  this.body.velocity.z = 30;
+  const { x, y, z } = this.position;
+  this.body.position.x = x;
+  this.body.position.y = y;
+  this.body.position.z = z;
+
+  this.body.velocity.x = 0;
+  this.body.velocity.y = 0;
+  this.body.velocity.z = -35;
 }
 
 Ball.prototype.bodyRef = function () {

--- a/src/cannon/objects/Bumper/config/index.js
+++ b/src/cannon/objects/Bumper/config/index.js
@@ -1,8 +1,7 @@
 import * as CANNON from 'cannon-es';
-import { bumperMaterial } from '../../../materials';
+import { bumperMaterial } from 'cannon/materials';
 import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
 import { bumperCollisionHandler, COLLISION_GROUPS } from 'cannon/collisions';
-import { PlaneBufferGeometry } from 'three';
 
 const bodyOffsetX = 0.45; 
 export const BUMPER_CONFIG = {
@@ -24,17 +23,17 @@ export const BUMPER_CONFIG = {
   locations: [    
     {
       bumperName: 'upper_left_bumper',
-      offset: new CANNON.Vec3(-2 + bodyOffsetX, 0.5, -5),
+      offset: new CANNON.Vec3(-2 + PLAYFIELD_CONSTANTS.offsetX, 0.5, -5),
       quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     },
     {
       bumperName: 'upper_right_bumper',
-      offset: new CANNON.Vec3(2 + bodyOffsetX, 0.5, -5),
+      offset: new CANNON.Vec3(2 + PLAYFIELD_CONSTANTS.offsetX, 0.5, -5),
       quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     },
     {
       bumperName: 'lower_center_bumper',
-      offset: new CANNON.Vec3(0  + bodyOffsetX, 0.5, -2),
+      offset: new CANNON.Vec3(0  + PLAYFIELD_CONSTANTS.offsetX, 0.5, -2),
       quaternion: PLAYFIELD_CONSTANTS.slopeQuaternion
     }
   ]

--- a/src/cannon/objects/WedgeFlipper/index.js
+++ b/src/cannon/objects/WedgeFlipper/index.js
@@ -94,8 +94,6 @@ WedgeFlipper.prototype.step = function () {
     hitArea: this.hitAreas[this.stepState.frame]
     }
   );
-
-console.log('flipperCollisionResults', flipperCollisionResults)
 // CHECK IF COLLISION FRAME
   if (flipperCollisionResults !== null) {
     const { ballVelocity, ballPosition } = flipperCollisionResults; 

--- a/src/cannon/triggers/DrainTrigger/configs/index.js
+++ b/src/cannon/triggers/DrainTrigger/configs/index.js
@@ -1,0 +1,20 @@
+import { Vec3, Box } from 'cannon-es';
+import { COLLISION_GROUPS } from 'cannon/collisions';
+import { PLAYFIELD_CONSTANTS } from 'cannon/constants';
+
+export const DRAIN_TRIGGER_CONFIG = {
+  mass: 0,
+  isTrigger: true,
+  collisionFilterGroup: COLLISION_GROUPS.TRIGGER,
+  collisionFilterMask: COLLISION_GROUPS.BALL,
+  elements: {
+    drainTrigger: {
+      xSize: 1,
+      ySize: 1,
+      zSize: 1,
+      get halfExtents() { return new Vec3(this.xSize/2, this.ySize/2, this.zSize/2) },
+      offset: new Vec3(0, -PLAYFIELD_CONSTANTS.slopeSin * 10.5 + .5, PLAYFIELD_CONSTANTS.slopeCos * 10.5),
+      get shape() { return new Box(this.halfExtents) }
+    }
+  }
+}

--- a/src/cannon/triggers/DrainTrigger/index.js
+++ b/src/cannon/triggers/DrainTrigger/index.js
@@ -1,0 +1,30 @@
+import { Body } from 'cannon-es';
+import { DRAIN_TRIGGER_CONFIG } from './configs';
+
+export function DrainTrigger ({ world }) {
+
+  const {
+    mass,
+    isTrigger,
+    collisionFilterGroup,
+    collisionFilterMask,
+    elements
+  } = DRAIN_TRIGGER_CONFIG;
+
+  this.body = new Body({
+    mass, 
+    isTrigger,
+    collisionFilterGroup,
+    collisionFilterMask
+    }
+  );
+
+  this.body.addShape(elements.drainTrigger.shape, elements.drainTrigger.offset);
+
+
+  world.addBody(this.body);
+}
+
+DrainTrigger.prototype.addCollideDispatch = function(callBack) {
+  this.body.addEventListener('collide', callBack);
+}

--- a/src/cannon/triggers/index.js
+++ b/src/cannon/triggers/index.js
@@ -1,0 +1,1 @@
+export { DrainTrigger } from './DrainTrigger';


### PR DESCRIPTION
Why: custom event needed to relay 'collide' cannon body event to ball.spawn() method.

A a 'trigger' object (DrainTrigger) wraps a cannon-es body positioned at the 'drain' of the pinball table. The body generates a 'collide' event when the ball passes into it. The DrainTrigger object can be assigned (via 'addCollideDispatch') a callback that dispatches the custom 'DRAIN_EVENT' (or any other custom event).