### PR TITLE
refine flipper contact physics

### DIFF
--- a/src/cannon/bodies/WedgeFlipper.js
+++ b/src/cannon/bodies/WedgeFlipper.js
@@ -81,7 +81,6 @@ export function WedgeFlipper ({
 
 // CREATE ANIMATION & DEFINE HIT AREAS
   const { animation, hitAreas } = createAnimation({ side }); //TODO move to helpers
-
 // CREATE FLIPPER CANNON BODY
   const body = new CANNON.Body({
     mass: 0,
@@ -160,6 +159,7 @@ export function WedgeFlipper ({
             wedgeBaseHeight,
             length: flipperLengthFromPivot,
             axis: axis[side],
+            endRadian: endRadian[side],
             body
           },
           side,
@@ -200,6 +200,7 @@ export function WedgeFlipper ({
       playfieldSlope.mult(quatAnimStep, quatMult);
       animation.push(quatMult);
     }
+    console.log('flipperAngles', flipperAngles)
     const hitAreas = flipperAngles.map((angle, idx) => {
       const hitArea = { min: null, max: null, minDegrees: null, maxDegrees: null };
       if (idx > 0) {


### PR DESCRIPTION
# Description

Because the speed of the pinball and the speed of the flipper's rotation exceeds cannon-es' ability to detect contact at 60fps, a 'predictive collision' method is used to approximate the direction and velocity of a flipper collision. This update refines this method in the following ways:
- When a collision occurs, the ball is placed at a point above the upward-rotated flipper. This prevents the flipper from passing through the ball.
- Rebound direction now takes into account the slope of the flipper's wedge shape.

https://github.com/patrick-s-young/pinball-xr/assets/42591798/fc7675ee-1548-4add-bd28-b70994077cb4

