### PR TITLE
Improve flipper collision prediction for fast shots

### DIFF
--- a/src/cannon/bodies/WedgeFlipper.helpers.js
+++ b/src/cannon/bodies/WedgeFlipper.helpers.js
@@ -1,5 +1,7 @@
 import * as CANNON from 'cannon-es';
-import { PLAYFIELD } from '@src/App.config';
+
+const EPSILON = 1e-6;
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
 export const getContactFrame = ({
   ball,
@@ -20,27 +22,32 @@ export const getContactFrame = ({
     flipperRotationAtPointOfContact: undefined,
     flipperAngleOfContact: undefined
   }
-
+  const dx = ball.position.x - flipper.body.position.x;
+  const dz = ball.position.z - flipper.body.position.z;
   // STEP 1: Distance between ball center and flipper pivot
-  distance.pivotToBallCenter = Math.sqrt(Math.pow(ball.position.x - flipper.body.position.x, 2) + Math.pow(ball.position.z - flipper.body.position.z, 2));
+  distance.pivotToBallCenter = Math.max(Math.sqrt(dx ** 2 + dz ** 2), EPSILON);
+  //distance.pivotToBallCenter = Math.sqrt(Math.pow(ball.position.x - flipper.body.position.x, 2) + Math.pow(ball.position.z - flipper.body.position.z, 2));
   // STEP 2: Angle of ball center and flipper pivot
-  angle.pivotToBallCenter = Math.atan((ball.position.z - flipper.body.position.z) / (ball.position.x - flipper.body.position.x));
-  if (side === 'right') angle.pivotToBallCenter += Math.PI;
+  angle.pivotToBallCenter = Math.atan2(dz, dx);
+  // angle.pivotToBallCenter = Math.atan2(
+  //   ball.position.z - flipper.body.position.z,
+  //   ball.position.x - flipper.body.position.x
+  // );
   // STEP 3: Angle between flipper pivot, ball center, and ball radius (extending perpendicular to angle.pivotToBallCenter)
   angle.ballCenterToPivotToBallSurface = Math.atan(ball.radius / distance.pivotToBallCenter);
   // STEP 4: Distance between pivot and ball radius (extending perpendicular to angle.pivotToBallCenter)
   distance.pivotToBallSurface = Math.abs(ball.radius / Math.sin(angle.ballCenterToPivotToBallSurface));
-
   // EXIT TEST: IS THE BALL CLOSE ENOUGH TO HIT?
   if (distance.pivotToBallSurface > flipper.length) {
     return null;
   }
-
   // STEP 5: Distance between ball and center of flipper (along length axis)
-  //distance.wedgeCenterToBallSurface = (flipper.length - distance.pivotToBallSurface) / flipper.length * flipper.wedgeBaseHeight;
-  distance.wedgeCenterToBallSurface = flipper.length * flipper.wedgeBaseHeight * (flipper.length - distance.pivotToBallSurface);
+  distance.wedgeCenterToBallSurface =
+    ((flipper.length - distance.pivotToBallSurface) / flipper.length) * flipper.wedgeBaseHeight;
   // STEP 6: Flipper rotation between ball and center of flipper
-  angle.ballSurfaceToPivotToWedgeCenter = Math.asin(distance.wedgeCenterToBallSurface / distance.pivotToBallSurface);
+  angle.ballSurfaceToPivotToWedgeCenter = Math.asin(
+    clamp(distance.wedgeCenterToBallSurface / distance.pivotToBallSurface, -1, 1)
+  );
   // STEP 7: Derive flipper rotation at point of contact with ball
     angle.flipperRotationAtPointOfContact = side === 'left' ?
       angle.pivotToBallCenter - angle.ballCenterToPivotToBallSurface - angle.ballSurfaceToPivotToWedgeCenter
@@ -72,6 +79,10 @@ export const getContactFrame = ({
     return null;
   }
 
+  // Normalize vector
+  const mag = Math.sqrt(tangentVelocity.x ** 2 + tangentVelocity.z ** 2);
+  tangentVelocity.x /= mag;
+  tangentVelocity.z /= mag;
 
   // STEP 10: Derive velocity vector based on position of ball relative to pivot
   const flipperMagnitude = distance.pivotToBallSurface / flipper.length;

--- a/src/cannon/bodies/WedgeFlipper.js
+++ b/src/cannon/bodies/WedgeFlipper.js
@@ -14,6 +14,10 @@ const playFieldSlopeOffsetY = PLAYFIELD.slopeSin * flipperOffsetZ;
 const playFieldSlipeOffsetZ = PLAYFIELD.slopeCos * flipperOffsetZ;
 const wedgeSlope = Math.atan(wedgeBaseHeight / flipperLengthFromPivot);
 const maxVelocity = 4;
+const FLIPPER_SWEEP_EXTRA_RADIUS = 0.03;
+const NEAR_FLIPPER_SUBSTEPS = 4;
+const FAST_BALL_SUBSTEPS = 6;
+const FAST_BALL_SPEED = 2.0;
 const shape = CannonWedge({ 
   widthX: flipperLengthFromPivot / 2, 
   heightY: flipperHeight / 2, 
@@ -142,17 +146,39 @@ export function WedgeFlipper ({
   function step () {
     if (flipperState.isAnimating === false) return; 
     const { position, previousPosition } = ballState.ref;
+    const previous = previousPosition || position;
   // BEGIN FRAME
     stepState.frame += stepState.direction;
   // UPDATE FLIPPER POSITION
     body.quaternion.copy(animation[stepState.frame]);
   // CHECK IF COLLISION FRAME
-    const flipperCollisionResults = flipperState.orientation === 'down' 
-      ? null 
-      : getContactFrame({
+    let flipperCollisionResults = null;
+    if (flipperState.orientation !== 'down') {
+      const prevDx = previous.x - axis[side].x;
+      const prevDz = previous.z - axis[side].z;
+      const currDx = position.x - axis[side].x;
+      const currDz = position.z - axis[side].z;
+      const prevDistance = Math.sqrt(prevDx ** 2 + prevDz ** 2);
+      const currentDistance = Math.sqrt(currDx ** 2 + currDz ** 2);
+      const nearDistance = flipperLengthFromPivot + ballState.radius + FLIPPER_SWEEP_EXTRA_RADIUS;
+      const isNearFlipper = Math.min(prevDistance, currentDistance) <= nearDistance;
+      const ballSpeed = ballState.ref.velocity.length();
+      const substeps = isNearFlipper
+        ? (ballSpeed > FAST_BALL_SPEED ? FAST_BALL_SUBSTEPS : NEAR_FLIPPER_SUBSTEPS)
+        : 1;
+
+      for (let i = 0; i < substeps; i++) {
+        const t = (i + 1) / substeps;
+        const interpolatedPosition = new CANNON.Vec3(
+          previous.x + (position.x - previous.x) * t,
+          previous.y + (position.y - previous.y) * t,
+          previous.z + (position.z - previous.z) * t
+        );
+
+        flipperCollisionResults = getContactFrame({
           ball: {
             radius: ballState.radius,
-            position
+            position: interpolatedPosition
           },
           flipper: {
             wedgeSlope,
@@ -165,7 +191,11 @@ export function WedgeFlipper ({
           side,
           hitArea: hitAreas[stepState.frame],
           maxVelocity
-      });
+        });
+
+        if (flipperCollisionResults !== null) break;
+      }
+    }
       
   // CHECK IF COLLISION FRAME
     if (flipperCollisionResults !== null) {


### PR DESCRIPTION
## Summary
- Reduce flipper/ball tunneling by sampling interpolated ball positions between `previousPosition` and current position while flipper is animating up.
- Add adaptive near-flipper substeps with a small conservative radius margin so high-speed shots are checked more thoroughly.
- Harden contact prediction math by clamping trig inputs and using a stable wedge-height relation to avoid NaN contact angles.

## Test plan
- [ ] Run `yarn dev` and reproduce high-speed shots at both flippers; verify fewer or no pass-through events.
- [ ] Validate left/right flipper behavior feels unchanged for normal-speed shots.
- [ ] Verify no regression where balls get stuck or jitter after flipper contact.